### PR TITLE
[Fix] email auto increment 옵션 삭제

### DIFF
--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -37,7 +37,7 @@ CREATE TABLE `oauth_accounts`
 
 CREATE TABLE `email_accounts`
 (
-    `account_id` BIGINT       NOT NULL AUTO_INCREMENT,
+    `account_id` BIGINT       NOT NULL,
     `email`      VARCHAR(320) NOT NULL,
     `password`   CHAR(60)     NOT NULL,
     PRIMARY KEY (`account_id`),


### PR DESCRIPTION
- email 의 `account_id` 값은 상속받으므로 `AUTO INCREMENT` 옵션을 삭제했습니다.